### PR TITLE
Remove end date from catalog item

### DIFF
--- a/datasources/includes/water-items.ejs
+++ b/datasources/includes/water-items.ejs
@@ -622,7 +622,6 @@
                 "featureInfoTemplate": "# {{name}}\n\n|||\n|-------|-------|\n|Station Name|{{name}}|\n|SOS2 Feature Type|{{type}}|\n|SOS2 ID|{{id}}|\n|Latitude|{{lat}}|\n|Longitude|{{lon}}|\n\n{{chart}}",
                 "observablePropertiesName": "Observation type",
                 "startDate": "1980-01-01T00:00:00+10",
-                "endDate": "2016-10-01T00:00:00+10",
                 "procedures": [
                     {
                         "identifier": "http://bom.gov.au/waterdata/services/tstypes/Pat3_C_B_1_YearlyMean",


### PR DESCRIPTION
We should remove this end date from this catalog item, because it unnecessarily stops it from using more recent data.