### PR TITLE
btn color fix

### DIFF
--- a/lib/Views/global.scss
+++ b/lib/Views/global.scss
@@ -117,6 +117,24 @@ body {
             stroke: #ddd !important;
         }
     }
+    .tjs-tabs__btn--selected{
+            color: $color-primary;
+            &:hover, &:focus{
+                    color: $color-primary;
+            }
+    }
+    .tjs-tabs__btn--tab{
+            &:hover, &:focus{
+                    color: darken($color-primary, 0.5);
+            }
+    }
+    .tjs-feature-info-panel__btn--close-feature{
+            &:hover, &:focus{
+              svg{
+                    fill: #ffffff;
+              }
 
+            }
+        }
 
 }


### PR DESCRIPTION
a quick fix to the total unreadable buttons on explorer window and the feature info close button due to neii colour scheme.

