### PR TITLE
Update Wofs layers

### DIFF
--- a/wwwroot/init/neii-water.json
+++ b/wwwroot/init/neii-water.json
@@ -741,9 +741,10 @@
               ],
               "items": [
                 {
-                  "layers": "WaterObservations",
-                  "url": "http://geoserver.nci.org.au/geoserver/NFRIP-WOfS/wms",
+                  "layers": "wofs_summary_wet",
+                  "url": "https://ows.services.dea.ga.gov.au",
                   "type": "wms",
+                  "availableDimensions": {},
                   "rectangle": [
                     111,
                     -45,
@@ -762,9 +763,10 @@
                   ]
                 },
                 {
-                  "layers": "ClearObservations",
-                  "url": "http://geoserver.nci.org.au/geoserver/NFRIP-WOfS/wms",
+                  "layers": "wofs_summary_clear",
+                  "url": "https://ows.services.dea.ga.gov.au",
                   "type": "wms",
+                  "availableDimensions": {},
                   "rectangle": [
                     111,
                     -45,
@@ -783,9 +785,10 @@
                   ]
                 },
                 {
-                  "layers": "WaterSummary",
-                  "url": "http://geoserver.nci.org.au/geoserver/NFRIP-WOfS/wms",
+                  "layers": "Water Observations from Space Statistics",
+                  "url": "https://ows.services.dea.ga.gov.au",
                   "type": "wms",
+                  "availableDimensions": {},
                   "rectangle": [
                     111,
                     -45,
@@ -804,9 +807,10 @@
                   ]
                 },
                 {
-                  "layers": "Confidence",
-                  "url": "http://geoserver.nci.org.au/geoserver/NFRIP-WOfS/wms",
+                  "layers": "wofs_filtered_summary_confidence",
+                  "url": "https://ows.services.dea.ga.gov.au",
                   "type": "wms",
+                  "availableDimensions": {},
                   "rectangle": [
                     112,
                     -45,
@@ -825,9 +829,11 @@
                   ]
                 },
                 {
-                  "layers": "WaterSummaryFiltered",
-                  "url": "http://geoserver.nci.org.au/geoserver/NFRIP-WOfS/wms",
+                  "layers": "wofs_filtered_summary",
+                  "url": "https://ows.services.dea.ga.gov.au",
                   "type": "wms",
+                  "availableStyles": "WOfS_filtered_frequency",
+                  "availableDimensions": {},
                   "rectangle": [
                     111,
                     -45,

--- a/wwwroot/init/neii-water.json
+++ b/wwwroot/init/neii-water.json
@@ -788,6 +788,7 @@
                   "layers": "Water Observations from Space Statistics",
                   "url": "https://ows.dea.ga.gov.au",
                   "type": "wms",
+                  "availableStyles": "WOfS_frequency",
                   "availableDimensions": {},
                   "rectangle": [
                     111,

--- a/wwwroot/init/neii-water.json
+++ b/wwwroot/init/neii-water.json
@@ -742,7 +742,7 @@
               "items": [
                 {
                   "layers": "wofs_summary_wet",
-                  "url": "https://ows.services.dea.ga.gov.au",
+                  "url": "https://ows.dea.ga.gov.au",
                   "type": "wms",
                   "availableDimensions": {},
                   "rectangle": [
@@ -764,7 +764,7 @@
                 },
                 {
                   "layers": "wofs_summary_clear",
-                  "url": "https://ows.services.dea.ga.gov.au",
+                  "url": "https://ows.dea.ga.gov.au",
                   "type": "wms",
                   "availableDimensions": {},
                   "rectangle": [
@@ -786,7 +786,7 @@
                 },
                 {
                   "layers": "Water Observations from Space Statistics",
-                  "url": "https://ows.services.dea.ga.gov.au",
+                  "url": "https://ows.dea.ga.gov.au",
                   "type": "wms",
                   "availableDimensions": {},
                   "rectangle": [
@@ -808,7 +808,7 @@
                 },
                 {
                   "layers": "wofs_filtered_summary_confidence",
-                  "url": "https://ows.services.dea.ga.gov.au",
+                  "url": "https://ows.dea.ga.gov.au",
                   "type": "wms",
                   "availableDimensions": {},
                   "rectangle": [
@@ -830,7 +830,7 @@
                 },
                 {
                   "layers": "wofs_filtered_summary",
-                  "url": "https://ows.services.dea.ga.gov.au",
+                  "url": "https://ows.dea.ga.gov.au",
                   "type": "wms",
                   "availableStyles": "WOfS_filtered_frequency",
                   "availableDimensions": {},


### PR DESCRIPTION
> The NEII viewer portal is currently pointing to http://geoserver.nci.org.au/geoserver/NFRIP-WOfS/wms?service=WMS&version=1.3.0&request=GetCapabilities for NEII Data Services - Conformant / Water / Water Observations from Space (GA). The NCI are going to decom that service at 2pm this afternoon, can we change it to point to https://ows.services.dea.ga.gov.au instead?

Wasn't a simple replacement of the base url, also had to change layer names, define some styles and stop the time dimension from coming through.